### PR TITLE
fix(requests): use curl_cffi to bypass Cloudflare protection

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -6,7 +6,7 @@ Usage is either running this program with the URL/pageid as an argument or calli
 '''
 
 import uuid
-import requests
+from curl_cffi import requests
 import json
 import threading
 import concurrent.futures
@@ -131,7 +131,7 @@ def downloadFile(url, file, post_data=None):
         with open(file, 'wb') as f:
             f.write(response.content)
         logging.debug(f'Successfully downloaded: {url} to: {file}')
-    except requests.exceptions.HTTPError as err:
+    except Exception as err:
         logging.warning(f'URL error Handling {url} or will try alt: {str(err)}')
 
         # Try again with different accessurls (very hacky!)
@@ -147,7 +147,7 @@ def downloadFile(url, file, post_data=None):
                         f.write(response.content)
                     logging.debug(f'Successfully downloaded through alt: {url2} to: {file}')
                     return
-                except requests.exceptions.HTTPError as err:
+                except Exception as err:
                     logging.warning(f'URL error alt method tried url {url2} Handling of: {str(err)}')
                     pass
         logging.error(f'Failed to succeed for url {url}')


### PR DESCRIPTION
Mattermost uses CloudFlare as a CDN, which prevents libraries like requests or httpx to work properly. HTTP calls will get rejected with a 403 forbidden.

This MR replaces `requests` with `curl_cffi`, which support browser impersonation. More [about the curl_cffi project](https://github.com/yifeikong/curl_cffi)

Along with the MR opened by @nilpunning (https://github.com/mu-ramadan/matterport-dl/pull/2), I was able to properly download a complete show and get it working with the embedded server